### PR TITLE
Allow to gain root privileges.

### DIFF
--- a/install
+++ b/install
@@ -2,8 +2,8 @@
 
 # Check for root rights
 if [[ $EUID -ne 0 ]]; then
-   echo "This install script must be run as root" 1>&2
-   exit 1
+   sudo "$0" "$@"
+   exit 0
 fi
 
 # This will remove old kittykernel versions, if present


### PR DESCRIPTION
Currently `install` checks if it was started as root, and exits if not. This makes running it a little more complicated than necesssary (IMHO), since the user will then have to re-run it as `sudo install`. 
Instead, this lets `install` check if it has root privileges, prompts for the password if not, and then run through installation as normal.

Cheers!
Fred